### PR TITLE
fix: reorder meta_info record fields

### DIFF
--- a/contracts/base_nft.aes
+++ b/contracts/base_nft.aes
@@ -55,8 +55,8 @@ contract BaseNFT =
     record meta_info = 
         { name: string
         , symbol: string
-        , metadata_type : metadata_type 
-        , base_url: option(string) }
+        , base_url: option(string)
+        , metadata_type : metadata_type }
     
     record state = 
         { owner: address
@@ -75,7 +75,7 @@ contract BaseNFT =
         require(String.length(symbol) >= 1, "STRING_TOO_SHORT_SYMBOL")
 
         { owner = Call.caller,
-          meta_info = { name = name, symbol = symbol, metadata_type = metadata_type, base_url = base_url },
+          meta_info = { name = name, symbol = symbol, base_url = base_url, metadata_type = metadata_type },
           owners = {},
           balances = {},
           approvals = {},


### PR DESCRIPTION
Needed to detect the NFT as impacts the record type. For the last two fields, there would be a way identify which one is the `option(string)` or the `metadata_type` but it wouldn't be recommended to accept/detect any order because inverting `name` and `symbol` makes a difference and could not be detected (unless the source code is parsed).  