### PR TITLE
fix: metadata datatype

### DIFF
--- a/contracts/base_nft.aes
+++ b/contracts/base_nft.aes
@@ -50,7 +50,7 @@ contract BaseNFT =
     // URL, IPFD, OBJECT_ID: string
     // MAP: map(string, string)
     datatype metadata_type = URL | IPFS | OBJECT_ID | MAP
-    datatype metadata = String(string) | Map(string, string)
+    datatype metadata = MetadataIdentifier(string) | MetadataMap(map(string, string))
 
     record meta_info = 
         { name: string
@@ -121,8 +121,8 @@ contract BaseNFT =
                             Some(v)
                         Some(base_url) =>
                             switch(v)
-                                String(s) =>
-                                    Some(String(String.concats([base_url, s])))
+                                MetadataIdentifier(s) =>
+                                    Some(MetadataIdentifier(String.concats([base_url, s])))
                 else
                     // Not an URL, so return the metadata as it is.
                     Some(v)

--- a/contracts/core/interfaces.aes
+++ b/contracts/core/interfaces.aes
@@ -19,7 +19,7 @@
 
 contract interface NFT =
     datatype metadata_type = URL | IPFS | OBJECT_ID | MAP
-    datatype metadata = String(string) | Map(string, string)
+    datatype metadata = MetadataIdentifier(string) | MetadataMap(map(string, string))
 
     record meta_info = 
         { name: string

--- a/contracts/credential.aes
+++ b/contracts/credential.aes
@@ -51,7 +51,7 @@ contract CredentialNFT =
     // URL, IPFD, OBJECT_ID: string
     // MAP: map(string, string)
     datatype metadata_type = URL | IPFS | OBJECT_ID | MAP
-    datatype metadata = String(string) | Map(string, string)
+    datatype metadata = MetadataIdentifier(string) | MetadataMap(map(string, string))
 
     record meta_info = 
         { name: string

--- a/contracts/mintable_burnable.aes
+++ b/contracts/mintable_burnable.aes
@@ -50,7 +50,7 @@ contract MintableBurnableNFT =
     // URL, IPFD, OBJECT_ID: string
     // MAP: map(string, string)
     datatype metadata_type = URL | IPFS | OBJECT_ID | MAP
-    datatype metadata = String(string) | Map(string, string)
+    datatype metadata = MetadataIdentifier(string) | MetadataMap(map(string, string))
 
     record meta_info = 
         { name: string
@@ -140,8 +140,8 @@ contract MintableBurnableNFT =
                             Some(v)
                         Some(base_url) =>
                             switch(v)
-                                String(s) =>
-                                    Some(String(String.concats([base_url, s])))
+                                MetadataIdentifier(s) =>
+                                    Some(MetadataIdentifier(String.concats([base_url, s])))
                 else
                     // Not an URL, so return the metadata as it is.
                     Some(v)

--- a/contracts/swappable.aes
+++ b/contracts/swappable.aes
@@ -51,7 +51,7 @@ contract SwappableNFT =
     // URL, IPFD, OBJECT_ID: string
     // MAP: map(string, string)
     datatype metadata_type = URL | IPFS | OBJECT_ID | MAP
-    datatype metadata = String(string) | Map(string, string)
+    datatype metadata = MetadataIdentifier(string) | MetadataMap(map(string, string))
 
     record meta_info = 
         { name: string
@@ -149,8 +149,8 @@ contract SwappableNFT =
                             Some(v)
                         Some(base_url) =>
                             switch(v)
-                                String(s) =>
-                                    Some(String(String.concats([base_url, s])))
+                                MetadataIdentifier(s) =>
+                                    Some(MetadataIdentifier(String.concats([base_url, s])))
                 else
                     // Not an URL, so return the metadata as it is.
                     Some(v)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.6'
 services:
 
   aeproject_node:
-    image: aeternity/aeternity:${NODE_TAG}-bundle
+    image: aeternity/aeternity:${NODE_TAG:-latest}-bundle
     hostname: node
     environment:
       AETERNITY_CONFIG: /home/aeternity/aeternity.yaml
@@ -11,7 +11,7 @@ services:
       - './docker/accounts.json:/home/aeternity/node/data/aecore/.genesis/accounts_test.json'
 
   aeproject_compiler:
-    image: aeternity/aesophia_http:${COMPILER_TAG}
+    image: aeternity/aesophia_http:${COMPILER_TAG:-v6.1.0}
     hostname: compiler
     ports:
       - '3080:3080'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,15 +12,16 @@
         "chai-as-promised": "^7.1.1"
       },
       "devDependencies": {
-        "@aeternity/aeproject": "^4.1.1",
+        "@aeternity/aeproject": "^4.1.5",
         "chai": "^4.3.6",
         "mocha": "^9.2.2"
       }
     },
     "node_modules/@aeternity/aepp-calldata": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@aeternity/aepp-calldata/-/aepp-calldata-1.2.0.tgz",
-      "integrity": "sha512-hrlT8B4I7clcGSypqT3ZAuuQbMjH3WD/xr4wnVoW6TrGZ7+0dk8xrgkx3yeZDeR5kGexwVq9Yqm/CGs9kfvOgQ==",
+      "resolved": "git+ssh://git@github.com/aeternity/aepp-calldata-js.git#5560c87936243b7484ee5cada09bd0f550f41308",
+      "integrity": "sha512-A8dJ5h+licvdrq6uljodrD1oy2aI6u5x7HIrKS9fzUBfOZFC+ev9nnHio7syF6S8hxw1spuz8oPbFx1IpxCZiw==",
+      "license": "ISC",
       "dependencies": {
         "blakejs": "^1.2.1",
         "bs58": "^4.0.1",
@@ -81,9 +82,9 @@
       }
     },
     "node_modules/@aeternity/aeproject": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@aeternity/aeproject/-/aeproject-4.1.4.tgz",
-      "integrity": "sha512-6dcXdgmQiYyqJ76B7kD87HndGhmZGAory4UNpU/nEMR3Nr3ewRg299q4Ppg2KYLWXOPXZKPw/y6kOQqy+nPPHQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@aeternity/aeproject/-/aeproject-4.1.5.tgz",
+      "integrity": "sha512-hatC+LFVo0kiR6lQxAP4D21KLToOfNc0UkANvxxmdkeehWJSmr4Yq6QK7WPs03zBG1e8d1W0vYiwh2Q5uRU+3g==",
       "dev": true,
       "dependencies": {
         "@aeternity/aepp-sdk": "^12.0.0",
@@ -1814,9 +1815,9 @@
   },
   "dependencies": {
     "@aeternity/aepp-calldata": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@aeternity/aepp-calldata/-/aepp-calldata-1.2.0.tgz",
-      "integrity": "sha512-hrlT8B4I7clcGSypqT3ZAuuQbMjH3WD/xr4wnVoW6TrGZ7+0dk8xrgkx3yeZDeR5kGexwVq9Yqm/CGs9kfvOgQ==",
+      "version": "git+ssh://git@github.com/aeternity/aepp-calldata-js.git#5560c87936243b7484ee5cada09bd0f550f41308",
+      "integrity": "sha512-A8dJ5h+licvdrq6uljodrD1oy2aI6u5x7HIrKS9fzUBfOZFC+ev9nnHio7syF6S8hxw1spuz8oPbFx1IpxCZiw==",
+      "from": "@aeternity/aepp-calldata@github:aeternity/aepp-calldata-js#5560c87936243b7484ee5cada09bd0f550f41308",
       "requires": {
         "blakejs": "^1.2.1",
         "bs58": "^4.0.1",
@@ -1848,7 +1849,7 @@
       "resolved": "https://registry.npmjs.org/@aeternity/aepp-sdk/-/aepp-sdk-12.1.2.tgz",
       "integrity": "sha512-OlqQzjChsbvgPLCT2p5egjx+meFSnSeEfmwr1JmzhIIg9CaCOlTBgx6zLw88BNyWAwUSAYVcgIF73XvH1yUF3A==",
       "requires": {
-        "@aeternity/aepp-calldata": "^1.2.0",
+        "@aeternity/aepp-calldata": "github:aeternity/aepp-calldata-js#5560c87936243b7484ee5cada09bd0f550f41308",
         "@aeternity/argon2-browser": "^0.1.2",
         "@aeternity/uuid": "^0.0.1",
         "@azure/core-client": "1.6.0",
@@ -1879,9 +1880,9 @@
       }
     },
     "@aeternity/aeproject": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@aeternity/aeproject/-/aeproject-4.1.4.tgz",
-      "integrity": "sha512-6dcXdgmQiYyqJ76B7kD87HndGhmZGAory4UNpU/nEMR3Nr3ewRg299q4Ppg2KYLWXOPXZKPw/y6kOQqy+nPPHQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@aeternity/aeproject/-/aeproject-4.1.5.tgz",
+      "integrity": "sha512-hatC+LFVo0kiR6lQxAP4D21KLToOfNc0UkANvxxmdkeehWJSmr4Yq6QK7WPs03zBG1e8d1W0vYiwh2Q5uRU+3g==",
       "dev": true,
       "requires": {
         "@aeternity/aepp-sdk": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "chai-as-promised": "^7.1.1"
   },
   "devDependencies": {
-    "@aeternity/aeproject": "^4.1.1",
+    "@aeternity/aeproject": "^4.1.5",
     "chai": "^4.3.6",
     "mocha": "^9.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.0",
   "description": "NFT examples and tooling for Aeternity",
   "scripts": {
-    "test": "mocha ./test/**/*.js --timeout 0 --exit"
+    "test": "mocha ./test/**/*.js --timeout 0 --exit",
+    "test:base": "mocha ./test/baseNFTTest.js --timeout 0 --exit",
+    "test:credential": "mocha ./test/credentialNFTTest.js --timeout 0 --exit",
+    "test:mintableburnable": "mocha ./test/mintableBurnableNFTTest.js --timeout 0 --exit",
+    "test:swappable": "mocha ./test/swappableNFTTest.js --timeout 0 --exit"
   },
   "dependencies": {
     "@aeternity/aepp-sdk": "^12.1.2",

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "@aeternity/aeproject": "^4.1.1",
     "chai": "^4.3.6",
     "mocha": "^9.2.2"
+  },
+  "overrides": {
+    "@aeternity/aepp-calldata": "github:aeternity/aepp-calldata-js#5560c87936243b7484ee5cada09bd0f550f41308"
   }
 }

--- a/test/baseNFTTest.js
+++ b/test/baseNFTTest.js
@@ -64,7 +64,7 @@ describe('base nft', () => {
   });
 
   it('NFT: define_token with contract owner', async () => {
-    const token = await contract.methods.define_token(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.define_token(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -73,13 +73,13 @@ describe('base nft', () => {
     // Should not be able to define the token again.
     await expect(
       contract.methods.define_token(wallets[0].publicKey, 
-      {'String': ['https://example.com/mynft']}, 
+      {'MetadataIdentifier': ['https://example.com/mynft']}, 
       { onAccount: accounts[0] }))
       .to.be.rejectedWith(`Invocation failed: "TOKEN_ALREADY_DEFINED"`);
 
     {
       const  { decodedResult } = await contract.methods.metadata(0);
-      assert.equal(decodedResult.String[0], 'https://example.com/mynft');
+      assert.equal(decodedResult.MetadataIdentifier[0], 'https://example.com/mynft');
     }
 
     {
@@ -109,7 +109,7 @@ describe('base nft', () => {
   it('NFT: define_token only by contract owner', async () => {
     await expect(
       contract.methods.define_token(wallets[0].publicKey, 
-      {'String': ['https://example.com/mynft']}, 
+      {'MetadataIdentifier': ['https://example.com/mynft']}, 
       { onAccount: accounts[1] }))
       .to.be.rejectedWith(`Invocation failed: "ONLY_CONTRACT_OWNER_CALL_ALLOWED"`);
   });
@@ -123,7 +123,7 @@ describe('base nft', () => {
       {'URL': []}
     ]);
 
-    const token = await contract.methods.define_token(wallets[0].publicKey, {'String': ['mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.define_token(wallets[0].publicKey, {'MetadataIdentifier': ['mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -131,7 +131,7 @@ describe('base nft', () => {
 
     {
       const  { decodedResult } = await contract.methods.metadata(0);
-      assert.equal(decodedResult.String[0], 'https://example.com/mynft');
+      assert.equal(decodedResult.MetadataIdentifier[0], 'https://example.com/mynft');
     }
 
     {
@@ -144,7 +144,7 @@ describe('base nft', () => {
   });
 
   it('NFT: transfer', async () => {
-    const token = await contract.methods.define_token(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.define_token(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -161,7 +161,7 @@ describe('base nft', () => {
   });
 
   it('NFT: approve', async () => {
-    const token = await contract.methods.define_token(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.define_token(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -200,7 +200,7 @@ describe('base nft', () => {
   });
 
   it('NFT: approve for all', async () => {
-    const token = await contract.methods.define_token(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.define_token(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -228,7 +228,7 @@ describe('base nft', () => {
   });
 
   it('NFT: unauthorized transfer', async () => {
-    const token = await contract.methods.define_token(wallets[1].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.define_token(wallets[1].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[1].publicKey);
@@ -240,7 +240,7 @@ describe('base nft', () => {
   });
 
   it('NFT: invalid transfer', async () => {
-    const token = await contract.methods.define_token(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.define_token(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -252,7 +252,7 @@ describe('base nft', () => {
   });
 
   it('NFT: safe transfer', async () => {
-    const token = await contract.methods.define_token(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.define_token(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -267,7 +267,7 @@ describe('base nft', () => {
   });
 
   it('NFT: failed safe transfer', async () => {
-    const token = await contract.methods.define_token(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.define_token(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);

--- a/test/credentialNFTTest.js
+++ b/test/credentialNFTTest.js
@@ -62,7 +62,8 @@ describe('credential nft', () => {
   });
 
   it('NFT: mint token', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
+    const metadataMap = new Map([['course', 'NFT101'],['score', 'A+']]);
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [metadataMap]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -73,7 +74,7 @@ describe('credential nft', () => {
 
     {
       const { decodedResult } = await contract.methods.metadata(0);
-      assert.deepEqual(decodedResult.MetadataMap, {course: "NFT 101", score: "A+" });
+      assert.deepEqual(decodedResult.MetadataMap[0], metadataMap);
     }
 
     {
@@ -92,7 +93,8 @@ describe('credential nft', () => {
     }
 
     let new_token_id = token_id + BigInt(1);
-    const token1 = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 201", score: "A+"}]}, { onAccount: accounts[0] });
+    const metadataMap2 = new Map([['course', 'NFT201'],['score', 'A+']]);
+    const token1 = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [metadataMap2]}, { onAccount: accounts[0] });
     assert.equal(token1.decodedEvents[0].name, 'Transfer');
     assert.equal(token1.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token1.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -101,16 +103,18 @@ describe('credential nft', () => {
   });
 
   it('NFT: mint only by contract owner', async () => {
+    const metadataMap = new Map([['course', 'NFT101'],['score', 'A+']]);
     await expect(
       contract.methods.mint(wallets[0].publicKey, 
-      {'MetadataMap': [{course: "NFT 101", score: "A+"}]},
+      {'MetadataMap': [metadataMap]},
       {'None': []}, 
       { onAccount: accounts[1] }))
       .to.be.rejectedWith(`Invocation failed: "ONLY_CONTRACT_OWNER_CALL_ALLOWED"`);
   });
 
   it('NFT: transfer', async () => {
-    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
+    const metadataMap = new Map([['course', 'NFT101'],['score', 'A+']]);
+    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [metadataMap]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[1].publicKey);
@@ -131,7 +135,8 @@ describe('credential nft', () => {
   });
 
   it('NFT: approve', async () => {
-    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
+    const metadataMap = new Map([['course', 'NFT101'],['score', 'A+']]);
+    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [metadataMap]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[1].publicKey);
@@ -169,7 +174,8 @@ describe('credential nft', () => {
   });
 
   it('NFT: approve for all', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
+    const metadataMap = new Map([['course', 'NFT101'],['score', 'A+']]);
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [metadataMap]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -186,7 +192,8 @@ describe('credential nft', () => {
   });
 
   it('NFT: invalid transfer', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
+    const metadataMap = new Map([['course', 'NFT101'],['score', 'A+']]);
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [metadataMap]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);

--- a/test/credentialNFTTest.js
+++ b/test/credentialNFTTest.js
@@ -73,7 +73,7 @@ describe('credential nft', () => {
 
     {
       const { decodedResult } = await contract.methods.metadata(0);
-      assert.deepEqual(decodedResult.Map, {course: "NFT 101", score: "A+" });
+      assert.deepEqual(decodedResult.MetadataMap, {course: "NFT 101", score: "A+" });
     }
 
     {

--- a/test/credentialNFTTest.js
+++ b/test/credentialNFTTest.js
@@ -13,6 +13,12 @@ describe('credential nft', () => {
   let fileSystem;
   let accounts;
 
+  // TODO change to the wanted keys if following issue is resolved (course & score)
+  // currently there seems to be an issue with keys in the map longer than 4 chars
+  // https://github.com/aeternity/aepp-calldata-js/issues/160
+  const metadataMap1 = new Map([['a','NFT 101'], ['b',"A+"]]);
+  const metadataMap2 = new Map([['a','NFT 201'], ['b',"A+"]]);
+
   before(async () => {
     aeSdk = await utils.getSdk();
 
@@ -62,7 +68,7 @@ describe('credential nft', () => {
   });
 
   it('NFT: mint token', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [metadataMap1]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -73,7 +79,7 @@ describe('credential nft', () => {
 
     {
       const { decodedResult } = await contract.methods.metadata(0);
-      assert.deepEqual(decodedResult.Map, {course: "NFT 101", score: "A+" });
+      assert.deepEqual(decodedResult.MetadataMap[0], metadataMap1);
     }
 
     {
@@ -92,7 +98,7 @@ describe('credential nft', () => {
     }
 
     let new_token_id = token_id + BigInt(1);
-    const token1 = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 201", score: "A+"}]}, { onAccount: accounts[0] });
+    const token1 = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [metadataMap2]}, { onAccount: accounts[0] });
     assert.equal(token1.decodedEvents[0].name, 'Transfer');
     assert.equal(token1.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token1.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -103,14 +109,14 @@ describe('credential nft', () => {
   it('NFT: mint only by contract owner', async () => {
     await expect(
       contract.methods.mint(wallets[0].publicKey, 
-      {'MetadataMap': [{course: "NFT 101", score: "A+"}]},
+      {'MetadataMap': [metadataMap1]},
       {'None': []}, 
       { onAccount: accounts[1] }))
       .to.be.rejectedWith(`Invocation failed: "ONLY_CONTRACT_OWNER_CALL_ALLOWED"`);
   });
 
   it('NFT: transfer', async () => {
-    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [metadataMap1]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[1].publicKey);
@@ -131,7 +137,7 @@ describe('credential nft', () => {
   });
 
   it('NFT: approve', async () => {
-    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [metadataMap1]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[1].publicKey);
@@ -169,7 +175,7 @@ describe('credential nft', () => {
   });
 
   it('NFT: approve for all', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [metadataMap1]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -186,7 +192,7 @@ describe('credential nft', () => {
   });
 
   it('NFT: invalid transfer', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [metadataMap1]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);

--- a/test/credentialNFTTest.js
+++ b/test/credentialNFTTest.js
@@ -13,12 +13,6 @@ describe('credential nft', () => {
   let fileSystem;
   let accounts;
 
-  // TODO change to the wanted keys if following issue is resolved (course & score)
-  // currently there seems to be an issue with keys in the map longer than 4 chars
-  // https://github.com/aeternity/aepp-calldata-js/issues/160
-  const metadataMap1 = new Map([['a','NFT 101'], ['b',"A+"]]);
-  const metadataMap2 = new Map([['a','NFT 201'], ['b',"A+"]]);
-
   before(async () => {
     aeSdk = await utils.getSdk();
 
@@ -68,7 +62,7 @@ describe('credential nft', () => {
   });
 
   it('NFT: mint token', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [metadataMap1]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -79,7 +73,7 @@ describe('credential nft', () => {
 
     {
       const { decodedResult } = await contract.methods.metadata(0);
-      assert.deepEqual(decodedResult.MetadataMap[0], metadataMap1);
+      assert.deepEqual(decodedResult.Map, {course: "NFT 101", score: "A+" });
     }
 
     {
@@ -98,7 +92,7 @@ describe('credential nft', () => {
     }
 
     let new_token_id = token_id + BigInt(1);
-    const token1 = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [metadataMap2]}, { onAccount: accounts[0] });
+    const token1 = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 201", score: "A+"}]}, { onAccount: accounts[0] });
     assert.equal(token1.decodedEvents[0].name, 'Transfer');
     assert.equal(token1.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token1.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -109,14 +103,14 @@ describe('credential nft', () => {
   it('NFT: mint only by contract owner', async () => {
     await expect(
       contract.methods.mint(wallets[0].publicKey, 
-      {'MetadataMap': [metadataMap1]},
+      {'MetadataMap': [{course: "NFT 101", score: "A+"}]},
       {'None': []}, 
       { onAccount: accounts[1] }))
       .to.be.rejectedWith(`Invocation failed: "ONLY_CONTRACT_OWNER_CALL_ALLOWED"`);
   });
 
   it('NFT: transfer', async () => {
-    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [metadataMap1]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[1].publicKey);
@@ -137,7 +131,7 @@ describe('credential nft', () => {
   });
 
   it('NFT: approve', async () => {
-    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [metadataMap1]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[1].publicKey);
@@ -175,7 +169,7 @@ describe('credential nft', () => {
   });
 
   it('NFT: approve for all', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [metadataMap1]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -192,7 +186,7 @@ describe('credential nft', () => {
   });
 
   it('NFT: invalid transfer', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [metadataMap1]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);

--- a/test/credentialNFTTest.js
+++ b/test/credentialNFTTest.js
@@ -62,7 +62,7 @@ describe('credential nft', () => {
   });
 
   it('NFT: mint token', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'Map': [["course", "NFT 101"], ["score", "A+"]]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -73,7 +73,7 @@ describe('credential nft', () => {
 
     {
       const { decodedResult } = await contract.methods.metadata(0);
-      assert.deepEqual(decodedResult.Map, [ 'course,NFT 101', 'score,A+' ]);
+      assert.deepEqual(decodedResult.Map, {course: "NFT 101", score: "A+" });
     }
 
     {
@@ -92,7 +92,7 @@ describe('credential nft', () => {
     }
 
     let new_token_id = token_id + BigInt(1);
-    const token1 = await contract.methods.mint(wallets[0].publicKey, {'Map': [["course", "NFT 201"], ["score", "A+"]]}, { onAccount: accounts[0] });
+    const token1 = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 201", score: "A+"}]}, { onAccount: accounts[0] });
     assert.equal(token1.decodedEvents[0].name, 'Transfer');
     assert.equal(token1.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token1.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -103,14 +103,14 @@ describe('credential nft', () => {
   it('NFT: mint only by contract owner', async () => {
     await expect(
       contract.methods.mint(wallets[0].publicKey, 
-      {'Map': [["course", "NFT 101"], ["score", "A+"]]},
+      {'MetadataMap': [{course: "NFT 101", score: "A+"}]},
       {'None': []}, 
       { onAccount: accounts[1] }))
       .to.be.rejectedWith(`Invocation failed: "ONLY_CONTRACT_OWNER_CALL_ALLOWED"`);
   });
 
   it('NFT: transfer', async () => {
-    const token = await contract.methods.mint(wallets[1].publicKey, {'Map': [["course", "NFT 101"], ["score", "A+"]]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[1].publicKey);
@@ -131,7 +131,7 @@ describe('credential nft', () => {
   });
 
   it('NFT: approve', async () => {
-    const token = await contract.methods.mint(wallets[1].publicKey, {'Map': [["course", "NFT 101"], ["score", "A+"]]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[1].publicKey);
@@ -169,7 +169,7 @@ describe('credential nft', () => {
   });
 
   it('NFT: approve for all', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'Map': [["course", "NFT 101"], ["score", "A+"]]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -186,7 +186,7 @@ describe('credential nft', () => {
   });
 
   it('NFT: invalid transfer', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'Map': [["course", "NFT 101"], ["score", "A+"]]}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataMap': [{course: "NFT 101", score: "A+"}]}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);

--- a/test/mintableBurnableNFTTest.js
+++ b/test/mintableBurnableNFTTest.js
@@ -64,7 +64,7 @@ describe('mintable, burnable nft', () => {
   });
 
   it('NFT: mint token', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -75,7 +75,7 @@ describe('mintable, burnable nft', () => {
 
     {
       const { decodedResult } = await contract.methods.metadata(0);
-      assert.equal(decodedResult.String[token_id], 'https://example.com/mynft');
+      assert.equal(decodedResult.MetadataIdentifier[token_id], 'https://example.com/mynft');
     }
 
     {
@@ -94,7 +94,7 @@ describe('mintable, burnable nft', () => {
     }
 
     let new_token_id = token_id + BigInt(1);
-    const token1 = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token1 = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token1.decodedEvents[0].name, 'Transfer');
     assert.equal(token1.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token1.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -105,14 +105,14 @@ describe('mintable, burnable nft', () => {
   it('NFT: mint only by contract owner', async () => {
     await expect(
       contract.methods.mint(wallets[0].publicKey, 
-      {'String': ['https://example.com/mynft']},
+      {'MetadataIdentifier': ['https://example.com/mynft']},
       {'None': []}, 
       { onAccount: accounts[1] }))
       .to.be.rejectedWith(`Invocation failed: "ONLY_CONTRACT_OWNER_CALL_ALLOWED"`);
   });
 
   it('NFT: burn token', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -126,7 +126,7 @@ describe('mintable, burnable nft', () => {
   });
 
   it('NFT: burn only by authorized', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -146,7 +146,7 @@ describe('mintable, burnable nft', () => {
       {'URL': []}
     ]);
 
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -154,7 +154,7 @@ describe('mintable, burnable nft', () => {
 
     {
       const  { decodedResult } = await contract.methods.metadata(0);
-      assert.equal(decodedResult.String[0], 'https://example.com/mynft');
+      assert.equal(decodedResult.MetadataIdentifier[0], 'https://example.com/mynft');
     }
 
     {
@@ -167,7 +167,7 @@ describe('mintable, burnable nft', () => {
   });
 
   it('NFT: transfer', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -184,7 +184,7 @@ describe('mintable, burnable nft', () => {
   });
 
   it('NFT: approve', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -223,7 +223,7 @@ describe('mintable, burnable nft', () => {
   });
 
   it('NFT: approve for all', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -251,7 +251,7 @@ describe('mintable, burnable nft', () => {
   });
 
   it('NFT: unauthorized transfer', async () => {
-    const token = await contract.methods.mint(wallets[1].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[1].publicKey);
@@ -263,7 +263,7 @@ describe('mintable, burnable nft', () => {
   });
 
   it('NFT: invalid transfer', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -275,7 +275,7 @@ describe('mintable, burnable nft', () => {
   });
 
   it('NFT: safe transfer', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -290,7 +290,7 @@ describe('mintable, burnable nft', () => {
   });
 
   it('NFT: failed safe transfer', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);

--- a/test/swappableNFTTest.js
+++ b/test/swappableNFTTest.js
@@ -64,7 +64,7 @@ describe('swappable nft', () => {
   });
 
   it('NFT: mint token', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -75,7 +75,7 @@ describe('swappable nft', () => {
 
     {
       const { decodedResult } = await contract.methods.metadata(0);
-      assert.equal(decodedResult.String[token_id], 'https://example.com/mynft');
+      assert.equal(decodedResult.MetadataIdentifier[token_id], 'https://example.com/mynft');
     }
 
     {
@@ -94,7 +94,7 @@ describe('swappable nft', () => {
     }
 
     let new_token_id = token_id + BigInt(1);
-    const token1 = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token1 = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token1.decodedEvents[0].name, 'Transfer');
     assert.equal(token1.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token1.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -105,15 +105,15 @@ describe('swappable nft', () => {
   it('NFT: mint only by contract owner', async () => {
     await expect(
       contract.methods.mint(wallets[0].publicKey, 
-      {'String': ['https://example.com/mynft']},
+      {'MetadataIdentifier': ['https://example.com/mynft']},
       {'None': []}, 
       { onAccount: accounts[1] }))
       .to.be.rejectedWith(`Invocation failed: "ONLY_CONTRACT_OWNER_CALL_ALLOWED"`);
   });
 
   it('NFT: swap token', async () => {
-    await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
-    await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     {
       const { decodedResult } = await contract.methods.balance(wallets[0].publicKey);
       assert.equal(decodedResult, 2);
@@ -154,7 +154,7 @@ describe('swappable nft', () => {
       {'URL': []}
     ]);
 
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -162,7 +162,7 @@ describe('swappable nft', () => {
 
     {
       const  { decodedResult } = await contract.methods.metadata(0);
-      assert.equal(decodedResult.String[0], 'https://example.com/mynft');
+      assert.equal(decodedResult.MetadataIdentifier[0], 'https://example.com/mynft');
     }
 
     {
@@ -175,7 +175,7 @@ describe('swappable nft', () => {
   });
 
   it('NFT: transfer', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -192,7 +192,7 @@ describe('swappable nft', () => {
   });
 
   it('NFT: approve', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -231,7 +231,7 @@ describe('swappable nft', () => {
   });
 
   it('NFT: approve for all', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -259,7 +259,7 @@ describe('swappable nft', () => {
   });
 
   it('NFT: unauthorized transfer', async () => {
-    const token = await contract.methods.mint(wallets[1].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[1].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[1].publicKey);
@@ -271,7 +271,7 @@ describe('swappable nft', () => {
   });
 
   it('NFT: invalid transfer', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -283,7 +283,7 @@ describe('swappable nft', () => {
   });
 
   it('NFT: safe transfer', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);
@@ -298,7 +298,7 @@ describe('swappable nft', () => {
   });
 
   it('NFT: failed safe transfer', async () => {
-    const token = await contract.methods.mint(wallets[0].publicKey, {'String': ['https://example.com/mynft']}, { onAccount: accounts[0] });
+    const token = await contract.methods.mint(wallets[0].publicKey, {'MetadataIdentifier': ['https://example.com/mynft']}, { onAccount: accounts[0] });
     assert.equal(token.decodedEvents[0].name, 'Transfer');
     assert.equal(token.decodedEvents[0].args[0].substr(2), contract.deployInfo.address.substr(2));
     assert.equal(token.decodedEvents[0].args[1], wallets[0].publicKey);


### PR DESCRIPTION
@davidyuk @dincho I get `NodeInvocationError` for `credentialNFTTest.js`:

```
NodeInvocationError: Invocation failed: "bad_call_data"
      at handleCallError (node_modules/@aeternity/aepp-sdk/dist/aepp-sdk.js:8055:11)
      at Object.instance.call (node_modules/@aeternity/aepp-sdk/dist/aepp-sdk.js:8219:7)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async Object.instance._estimateGas (node_modules/@aeternity/aepp-sdk/dist/aepp-sdk.js:8087:9)
      at async Object.instance.call (node_modules/@aeternity/aepp-sdk/dist/aepp-sdk.js:8232:108)
      at async Context.<anonymous> (test/credentialNFTTest.js:65:19)
```

I have no idea what the problem is. calldata usage seems to be fine but somehow it seems to be a bug. otherwise the node wouldn't complain 🤷‍♂️ 

I know it's friday evening. but it would be awesome to have this fixed asap because I need to make a presentation about how to create an NFT 😅 